### PR TITLE
CPU Singleton Schedule

### DIFF
--- a/dace/codegen/targets/cpu.py
+++ b/dace/codegen/targets/cpu.py
@@ -1755,7 +1755,7 @@ class CPUCodeGen(TargetCodeGenerator):
 
         # TODO: Explicit map unroller
         if node.map.unroll:
-            if node.map.schedule == dtypes.ScheduleType.CPU_Multicore:
+            if node.map.schedule in [dtypes.ScheduleType.CPU_Multicore, dtypes.ScheduleType.CPU_Multicore_Singleton]:
                 raise ValueError("A Multicore CPU map cannot be unrolled (" + node.map.label + ")")
 
         constsize = all([not symbolic.issymbolic(v, sdfg.constants) for r in node.map.range for v in r])

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -62,6 +62,7 @@ class ScheduleType(aenum.AutoNumberEnum):
     Sequential = ()  #: Sequential code (single-thread)
     MPI = ()  #: MPI processes
     CPU_Multicore = ()  #: OpenMP
+    CPU_Multicore_Singleton = ()  #: OpenMP, schedule exactly one task per thread
     Unrolled = ()  #: Unrolled code
     SVE_Map = ()  #: Arm SVE
 
@@ -204,6 +205,7 @@ SCOPEDEFAULT_SCHEDULE = {
     ScheduleType.Sequential: ScheduleType.Sequential,
     ScheduleType.MPI: ScheduleType.CPU_Multicore,
     ScheduleType.CPU_Multicore: ScheduleType.Sequential,
+    ScheduleType.CPU_Multicore_Singleton: ScheduleType.Sequential,
     ScheduleType.Unrolled: ScheduleType.CPU_Multicore,
     ScheduleType.GPU_Default: ScheduleType.GPU_Device,
     ScheduleType.GPU_Persistent: ScheduleType.GPU_Device,

--- a/dace/dtypes.py
+++ b/dace/dtypes.py
@@ -188,6 +188,7 @@ SCOPEDEFAULT_STORAGE = {
     ScheduleType.Sequential: StorageType.Register,
     ScheduleType.MPI: StorageType.CPU_Heap,
     ScheduleType.CPU_Multicore: StorageType.Register,
+    ScheduleType.CPU_Multicore_Singleton: StorageType.Register,
     ScheduleType.GPU_Default: StorageType.GPU_Global,
     ScheduleType.GPU_Persistent: StorageType.GPU_Global,
     ScheduleType.GPU_Device: StorageType.GPU_Shared,
@@ -1420,7 +1421,7 @@ def can_access(schedule: ScheduleType, storage: StorageType):
             ScheduleType.GPU_Default,
     ]:
         return storage in [StorageType.GPU_Global, StorageType.GPU_Shared, StorageType.CPU_Pinned]
-    elif schedule in [ScheduleType.Default, ScheduleType.CPU_Multicore]:
+    elif schedule in [ScheduleType.Default, ScheduleType.CPU_Multicore, ScheduleType.CPU_Multicore_Singleton]:
         return storage in [
             StorageType.Default, StorageType.CPU_Heap, StorageType.CPU_Pinned, StorageType.CPU_ThreadLocal
         ]
@@ -1448,20 +1449,32 @@ def can_allocate(storage: StorageType, schedule: ScheduleType):
     # Host-only allocation
     if storage in [StorageType.CPU_Heap, StorageType.CPU_Pinned, StorageType.CPU_ThreadLocal]:
         return schedule in [
-            ScheduleType.CPU_Multicore, ScheduleType.Sequential, ScheduleType.MPI, ScheduleType.GPU_Default
+            ScheduleType.CPU_Multicore,
+            ScheduleType.CPU_Multicore_Singleton,
+            ScheduleType.Sequential,
+            ScheduleType.MPI,
+            ScheduleType.GPU_Default,
         ]
 
     # GPU-global memory
     if storage is StorageType.GPU_Global:
         return schedule in [
-            ScheduleType.CPU_Multicore, ScheduleType.Sequential, ScheduleType.MPI, ScheduleType.GPU_Default
+            ScheduleType.CPU_Multicore,
+            ScheduleType.CPU_Multicore_Singleton,
+            ScheduleType.Sequential,
+            ScheduleType.MPI,
+            ScheduleType.GPU_Default,
         ]
 
     # FPGA-global memory
     if storage is StorageType.FPGA_Global:
         return schedule in [
-            ScheduleType.CPU_Multicore, ScheduleType.Sequential, ScheduleType.MPI, ScheduleType.FPGA_Device,
-            ScheduleType.GPU_Default
+            ScheduleType.CPU_Multicore,
+            ScheduleType.CPU_Multicore_Singleton,
+            ScheduleType.Sequential,
+            ScheduleType.MPI,
+            ScheduleType.FPGA_Device,
+            ScheduleType.GPU_Default,
         ]
 
     # FPGA-local memory

--- a/tests/thread_singleton_test.py
+++ b/tests/thread_singleton_test.py
@@ -1,0 +1,73 @@
+import dace
+from dace import dtypes, nodes
+import numpy as np
+
+
+N = dace.symbol("N")
+
+
+@dace.program
+def cpu_singleton_program(A: dace.int32[N]):
+    for i in dace.map[0:N]:
+        A[i] = i
+
+
+@dace.program
+def cpu_singleton_program_invalid_map_ranges(A: dace.int32[N]):
+    # We can only have one range with the `CPU_Multicore_Singleton` schedule!
+    for i, j in dace.map[0:N, 0:N]:
+        A[i] = i
+
+
+def first_map_entry_to_cpu_singleton(sdfg: dace.SDFG) -> None:
+    map_entry = None
+    for node, _ in sdfg.all_nodes_recursive():
+        if isinstance(node, nodes.MapEntry):
+            map_entry = node
+            break
+
+    map_entry.schedule = dtypes.ScheduleType.CPU_Multicore_Singleton
+
+
+def test_cpu_singleton() -> None:
+    N = 128
+
+    A = np.ndarray([N], dtype=np.int32)
+    A[:] = -1
+
+    sdfg = cpu_singleton_program.to_sdfg()
+    first_map_entry_to_cpu_singleton(sdfg)
+
+    sdfg(A, N=N)
+    threads = np.max(A) + 1
+    tasks = np.count_nonzero(A != -1)
+    assert threads == tasks
+    print(f"OK. Detected threads: {threads}")
+    print(f"OK. Scheduled tasks: {tasks}/{N}")
+
+
+def test_cpu_singleton_invalid_map_ranges() -> None:
+    N = 128
+
+    A = np.ndarray([N], dtype=np.int32)
+    A[:] = -1
+
+    sdfg = cpu_singleton_program_invalid_map_ranges.to_sdfg()
+    first_map_entry_to_cpu_singleton(sdfg)
+
+    try:
+        sdfg(A, N=N)
+    except ValueError as v:
+        assert (
+            "A CPU Thread Singleton map can only have one range" in v.args[0]
+        ), "Wrong exception message!"
+        print("OK. Exception correctly thrown.")
+    except:
+        assert False, "Wrong exception was thrown!"
+    else:
+        assert False, "No exception was throwng!"
+
+
+if __name__ == "__main__":
+    test_cpu_singleton()
+    test_cpu_singleton_invalid_map_ranges()

--- a/tests/thread_singleton_test.py
+++ b/tests/thread_singleton_test.py
@@ -9,7 +9,10 @@ N = dace.symbol("N")
 @dace.program
 def cpu_singleton_program(A: dace.int32[N]):
     for i in dace.map[0:N]:
-        A[i] = i
+        with dace.tasklet:
+            # Assuming OpenMP is used
+            t = omp_get_thread_num()
+            t >> A[i]
 
 
 @dace.program


### PR DESCRIPTION
Rather basic implementation of a schedule that runs exactly one task per thread.
This may be useful for, e.g., calling `MPI_Init` for each thread.

However, it does not really fit well conceptionally into dace's maps.

The approach requires that the dace map has only one range. The variable of that range is initialized with the current thread id (`omp_get_thread_num()`). So the range is completely ignored and will effectively be `0:omp_get_num_threads()`.